### PR TITLE
Change checkParameters() error messages to always give name of function

### DIFF
--- a/src/main/java/net/rptools/parser/function/AbstractComparisonFunction.java
+++ b/src/main/java/net/rptools/parser/function/AbstractComparisonFunction.java
@@ -34,8 +34,9 @@ public abstract class AbstractComparisonFunction extends AbstractLogicalOperator
   }
 
   @Override
-  public void checkParameters(List<Object> parameters) throws ParameterException {
-    super.checkParameters(parameters);
+  public void checkParameters(String functionName, List<Object> parameters)
+      throws ParameterException {
+    super.checkParameters(functionName, parameters);
 
     for (Object param : parameters) {
       if (!(param instanceof BigDecimal) && !(param instanceof String))

--- a/src/main/java/net/rptools/parser/function/AbstractLogicalOperatorFunction.java
+++ b/src/main/java/net/rptools/parser/function/AbstractLogicalOperatorFunction.java
@@ -34,8 +34,9 @@ public abstract class AbstractLogicalOperatorFunction extends AbstractFunction {
   }
 
   @Override
-  public void checkParameters(List<Object> parameters) throws ParameterException {
-    super.checkParameters(parameters);
+  public void checkParameters(String functionName, List<Object> parameters)
+      throws ParameterException {
+    super.checkParameters(functionName, parameters);
 
     for (Object param : parameters) {
       if (!(param instanceof Boolean)

--- a/src/main/java/net/rptools/parser/function/AbstractNumberFunction.java
+++ b/src/main/java/net/rptools/parser/function/AbstractNumberFunction.java
@@ -32,8 +32,9 @@ public abstract class AbstractNumberFunction extends AbstractFunction {
   }
 
   @Override
-  public void checkParameters(List<Object> parameters) throws ParameterException {
-    super.checkParameters(parameters);
+  public void checkParameters(String functionName, List<Object> parameters)
+      throws ParameterException {
+    super.checkParameters(functionName, parameters);
 
     for (Object param : parameters) {
       if (!(param instanceof BigDecimal))

--- a/src/main/java/net/rptools/parser/function/Function.java
+++ b/src/main/java/net/rptools/parser/function/Function.java
@@ -26,7 +26,8 @@ public interface Function {
   public Object evaluate(Parser parser, String functionName, List<Object> parameters)
       throws ParserException;
 
-  public void checkParameters(List<Object> parameters) throws ParameterException;
+  public void checkParameters(String functionName, List<Object> parameters)
+      throws ParameterException;
 
   public int getMinimumParameterCount();
 

--- a/src/main/java/net/rptools/parser/function/impl/Addition.java
+++ b/src/main/java/net/rptools/parser/function/impl/Addition.java
@@ -56,8 +56,9 @@ public class Addition extends AbstractFunction {
   }
 
   @Override
-  public void checkParameters(List<Object> parameters) throws ParameterException {
-    super.checkParameters(parameters);
+  public void checkParameters(String functionName, List<Object> parameters)
+      throws ParameterException {
+    super.checkParameters(functionName, parameters);
 
     for (Object param : parameters) {
       if (!(param instanceof BigDecimal || param instanceof String))

--- a/src/main/java/net/rptools/parser/function/impl/Equals.java
+++ b/src/main/java/net/rptools/parser/function/impl/Equals.java
@@ -54,8 +54,9 @@ public class Equals extends AbstractFunction {
   }
 
   @Override
-  public void checkParameters(List<Object> parameters) throws ParameterException {
-    super.checkParameters(parameters);
+  public void checkParameters(String functionName, List<Object> parameters)
+      throws ParameterException {
+    super.checkParameters(functionName, parameters);
 
     for (Object param : parameters) {
       if (!(param instanceof BigDecimal || param instanceof String))

--- a/src/main/java/net/rptools/parser/function/impl/Eval.java
+++ b/src/main/java/net/rptools/parser/function/impl/Eval.java
@@ -49,8 +49,9 @@ public class Eval extends AbstractFunction {
   }
 
   @Override
-  public void checkParameters(List<Object> parameters) throws ParameterException {
-    super.checkParameters(parameters);
+  public void checkParameters(String functionName, List<Object> parameters)
+      throws ParameterException {
+    super.checkParameters(functionName, parameters);
 
     for (Object param : parameters) {
       if (!(param instanceof String))

--- a/src/main/java/net/rptools/parser/function/impl/Mean.java
+++ b/src/main/java/net/rptools/parser/function/impl/Mean.java
@@ -48,8 +48,9 @@ public class Mean extends AbstractFunction {
   }
 
   @Override
-  public void checkParameters(List<Object> parameters) throws ParameterException {
-    super.checkParameters(parameters);
+  public void checkParameters(String functionName, List<Object> parameters)
+      throws ParameterException {
+    super.checkParameters(functionName, parameters);
 
     for (Object param : parameters) {
       if (!(param instanceof BigDecimal))

--- a/src/main/java/net/rptools/parser/function/impl/Median.java
+++ b/src/main/java/net/rptools/parser/function/impl/Median.java
@@ -64,8 +64,9 @@ public class Median extends AbstractFunction {
   }
 
   @Override
-  public void checkParameters(List<Object> parameters) throws ParameterException {
-    super.checkParameters(parameters);
+  public void checkParameters(String functionName, List<Object> parameters)
+      throws ParameterException {
+    super.checkParameters(functionName, parameters);
 
     for (Object param : parameters) {
       if (!(param instanceof BigDecimal))

--- a/src/main/java/net/rptools/parser/function/impl/NotEquals.java
+++ b/src/main/java/net/rptools/parser/function/impl/NotEquals.java
@@ -51,8 +51,9 @@ public class NotEquals extends AbstractFunction {
   }
 
   @Override
-  public void checkParameters(List<Object> parameters) throws ParameterException {
-    super.checkParameters(parameters);
+  public void checkParameters(String functionName, List<Object> parameters)
+      throws ParameterException {
+    super.checkParameters(functionName, parameters);
 
     for (Object param : parameters) {
       if (!(param instanceof BigDecimal || param instanceof String))

--- a/src/main/java/net/rptools/parser/function/impl/StrEquals.java
+++ b/src/main/java/net/rptools/parser/function/impl/StrEquals.java
@@ -42,8 +42,9 @@ public class StrEquals extends AbstractFunction {
   }
 
   @Override
-  public void checkParameters(List<Object> parameters) throws ParameterException {
-    super.checkParameters(parameters);
+  public void checkParameters(String functionName, List<Object> parameters)
+      throws ParameterException {
+    super.checkParameters(functionName, parameters);
 
     for (Object param : parameters) {
       if (!(param instanceof String))

--- a/src/main/java/net/rptools/parser/function/impl/StrNotEquals.java
+++ b/src/main/java/net/rptools/parser/function/impl/StrNotEquals.java
@@ -51,8 +51,9 @@ public class StrNotEquals extends AbstractFunction {
   }
 
   @Override
-  public void checkParameters(List<Object> parameters) throws ParameterException {
-    super.checkParameters(parameters);
+  public void checkParameters(String functionName, List<Object> parameters)
+      throws ParameterException {
+    super.checkParameters(functionName, parameters);
 
     for (Object param : parameters) {
       if (!(param instanceof BigDecimal || param instanceof String))


### PR DESCRIPTION
- Change wrong number of parameters error messages to always display name of function
- checkParameters method in AbstractFunction changed to take functionName as first argument
- Need to do: change every checkParameters(parameters) in Maptool project to checkParameters(functionName, parameters)
- Parser changes to close #2
- New error message for math functions. For example, for `Floor()`,

Old error message:

> Invalid number of parameters 0, expected exactly 1 parameter(s)

New error message:


> Function 'Floor' requires exactly 1 parameters; 0 were provided.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/parser/3)
<!-- Reviewable:end -->
