### PR TITLE
Fix for generation of source java from antlr source

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ import java.text.SimpleDateFormat
 buildscript {
     dependencies {
         classpath "com.diffplug.spotless:spotless-plugin-gradle:3.13.0"
+        classpath 'antlr:antlr:2.7.7'
     }
 
     repositories {
@@ -13,6 +14,7 @@ buildscript {
 // Access Git info from build script
 plugins {
     id "org.ajoberstar.grgit" version "3.0.0"
+    id 'antlr'
 }
 
 
@@ -40,6 +42,7 @@ dependencies {
     compile 'antlr:antlr:2.7.6'
     compile 'net.rptools.parser:parser:1.1.b24'
     testCompile group: 'junit', name: 'junit', version: '4.11'
+    antlr 'antlr:antlr:2.7.7'
 }
 
 // Custom properties
@@ -65,6 +68,10 @@ group = "net.rptools.parser"
 
 spotless {
     java {
+        target project.fileTree(project.rootDir) {
+            include 'src/**/*.java'
+            exclude '**/generated-src/'
+        }
         licenseHeaderFile 'spotless.license.java'
         // Now using the Google Java style guide
         //eclipse().configFile('build-resources/eclipse.prefs.formatter.xml')


### PR DESCRIPTION
Fixed the gradle build file so that the parser can be built from the command line with just gradle build.

Fixes #4

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/parser/5)
<!-- Reviewable:end -->
