### PR TITLE
Add macroStackTrace to the parser

### DIFF
--- a/src/main/java/net/rptools/parser/ParserException.java
+++ b/src/main/java/net/rptools/parser/ParserException.java
@@ -14,9 +14,15 @@
  */
 package net.rptools.parser;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class ParserException extends Exception {
 
   private static final long serialVersionUID = 1959865440126054220L;
+
+  /** The list of macro calls that resulted in the error. */
+  private final List<String> macroStackTrace = new ArrayList<>();
 
   public ParserException(Throwable cause) {
     super(cause);
@@ -24,5 +30,19 @@ public class ParserException extends Exception {
 
   public ParserException(String msg) {
     super(msg);
+  }
+
+  /**
+   * Add the macro / udf name to the stackTrace.
+   *
+   * @param name the macro or UDF name
+   */
+  public void addMacro(String name) {
+    macroStackTrace.add(name);
+  }
+
+  /** @return an array representing the macro stack trace. */
+  public String[] getMacroStackTrace() {
+    return macroStackTrace.toArray(new String[0]);
   }
 }


### PR DESCRIPTION
- Add methods addMacro and getMacroStackTrace to ParserException to add to, and return, the macro stack trace associated with the error
- Part of RPTools/maptool#1861

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/parser/27)
<!-- Reviewable:end -->
