### PR TITLE
Add support for logical operators to Expression.format()/InlineTreeFormatter

### DIFF
--- a/src/main/java/net/rptools/parser/InlineTreeFormatter.java
+++ b/src/main/java/net/rptools/parser/InlineTreeFormatter.java
@@ -14,14 +14,7 @@
  */
 package net.rptools.parser;
 
-import static net.rptools.parser.ExpressionParserTokenTypes.ASSIGNEE;
-import static net.rptools.parser.ExpressionParserTokenTypes.FUNCTION;
-import static net.rptools.parser.ExpressionParserTokenTypes.HEXNUMBER;
-import static net.rptools.parser.ExpressionParserTokenTypes.NUMBER;
-import static net.rptools.parser.ExpressionParserTokenTypes.OPERATOR;
-import static net.rptools.parser.ExpressionParserTokenTypes.STRING;
-import static net.rptools.parser.ExpressionParserTokenTypes.UNARY_OPERATOR;
-import static net.rptools.parser.ExpressionParserTokenTypes.VARIABLE;
+import static net.rptools.parser.ExpressionParserTokenTypes.*;
 
 import antlr.collections.AST;
 import java.util.HashMap;
@@ -35,12 +28,23 @@ public class InlineTreeFormatter {
 
   static {
     // P(1) E(2) MD(3) AS(4):
-    ORDER_OF_OPERATIONS.put("=", 0);
+    // provide order-of for all operators as per
+    // https://en.wikipedia.org/wiki/Order_of_operations#Programming_languages
+    // Note that parser historically places operator = first
+    ORDER_OF_OPERATIONS.put("=", 1);
     ORDER_OF_OPERATIONS.put("^", 2);
     ORDER_OF_OPERATIONS.put("*", 3);
     ORDER_OF_OPERATIONS.put("/", 3);
     ORDER_OF_OPERATIONS.put("+", 4);
     ORDER_OF_OPERATIONS.put("-", 4);
+    ORDER_OF_OPERATIONS.put("<", 6);
+    ORDER_OF_OPERATIONS.put("<=", 6);
+    ORDER_OF_OPERATIONS.put(">", 6);
+    ORDER_OF_OPERATIONS.put(">=", 6);
+    ORDER_OF_OPERATIONS.put("==", 7);
+    ORDER_OF_OPERATIONS.put("!=", 7);
+    ORDER_OF_OPERATIONS.put("&&", 11);
+    ORDER_OF_OPERATIONS.put("||", 13);
   }
 
   public String format(AST node) throws EvaluationException, ParameterException {
@@ -48,6 +52,12 @@ public class InlineTreeFormatter {
     format(node, sb);
 
     return sb.toString();
+  }
+
+  private int getOrderOfOperator(String op) {
+    Integer result = ORDER_OF_OPERATIONS.get(op);
+    // revert to a default high order of for any not mapped operator
+    return result == null ? Integer.MAX_VALUE : result;
   }
 
   private void format(AST node, StringBuilder sb) throws EvaluationException, ParameterException {
@@ -59,6 +69,8 @@ public class InlineTreeFormatter {
       case VARIABLE:
       case NUMBER:
       case HEXNUMBER:
+      case TRUE:
+      case FALSE:
         {
           sb.append(node.getText());
           return;
@@ -73,12 +85,12 @@ public class InlineTreeFormatter {
         }
       case OPERATOR:
         {
-          int currentLevel = ORDER_OF_OPERATIONS.get(node.getText());
+          int currentLevel = getOrderOfOperator(node.getText());
 
           AST child = node.getFirstChild();
           while (child != null) {
             if (child.getType() == OPERATOR) {
-              int childLevel = ORDER_OF_OPERATIONS.get(child.getText());
+              int childLevel = getOrderOfOperator(child.getText());
               if (currentLevel < childLevel) sb.append("(");
               format(child, sb);
               if (currentLevel < childLevel) sb.append(")");

--- a/src/test/java/net/rptools/parser/InlineTreeFormatterTest.java
+++ b/src/test/java/net/rptools/parser/InlineTreeFormatterTest.java
@@ -51,13 +51,37 @@ public class InlineTreeFormatterTest extends TestCase {
     compare("eval('2*2')", "eval('2*2')");
   }
 
+  public void testLogicalOperators()
+      throws ParserException, EvaluationException, ParameterException {
+    /**
+     * OR : "||" ; AND : "&&" ; NOT : '!' ; EQUALS : "==" ; NOTEQUALS : "!=" ; GE : ">=" ; GT : ">"
+     * ; LT : "<" ; LE : "<=" ; TRUE : "true"; FALSE : "false";
+     */
+    compare("1||1", "1 || 1");
+    compare("1||1", "1 || 1");
+    compare("1&&1", "1 && 1");
+
+    compare("x<2||x>3", "x < 2 || x > 3");
+    compare("1&&1 || 0||1", "1 && 1 || 0 || 1");
+    compare("1||1 && 0||1", "1 || 1 && 0 || 1");
+    compare("(1||1)&&(0||1)", "(1 || 1) && (0 || 1)");
+
+    compare("!true", "!true");
+    compare("1==1", "1 == 1");
+    compare("a!=b", "a != b");
+    compare("1>2", "1 > 2");
+    compare("1+1>=2+2", "1 + 1 >= 2 + 2");
+    compare("1<2", "1 < 2");
+    compare("1+1<=2+2", "1 + 1 <= 2 + 2");
+    compare("true == (true && false) && false", "true == (true && false) && false");
+    compare("true", "true");
+    compare("false", "false");
+  }
+
   private void compare(String expression, String expected)
       throws ParserException, EvaluationException, ParameterException {
     Parser p = new Parser();
     Expression xp = p.parseExpression(expression);
-
-    InlineTreeFormatter tf = new InlineTreeFormatter();
-
-    assertEquals(expected, tf.format(xp.getTree()));
+    assertEquals(expected, xp.format());
   }
 }


### PR DESCRIPTION
support formatting of logical operators

`new Parser().parseExpression('1 == 1').format().equals('1 == 1')`

Add unit-tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/parser/37)
<!-- Reviewable:end -->
