### PR TITLE
Make +, ==, !=, eqs, neqs work for non-string/bigdecimal arguments

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.3.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/net/rptools/parser/function/AbstractFunction.java
+++ b/src/main/java/net/rptools/parser/function/AbstractFunction.java
@@ -14,6 +14,7 @@
  */
 package net.rptools.parser.function;
 
+import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.parser.Parser;
 import net.rptools.parser.ParserException;
@@ -97,14 +98,11 @@ public abstract class AbstractFunction implements Function {
     }
   }
 
-  public void checkParameterTypes(List<Object> parameters, List<Class> allowedTypes) {}
-
-  protected boolean containsString(List<Object> parameters) {
+  protected boolean containsOnlyBigDecimals(List<Object> parameters) {
     for (Object param : parameters) {
-      if (param instanceof String) return true;
+      if (!(param instanceof BigDecimal)) return false;
     }
-
-    return false;
+    return true;
   }
 
   public abstract Object childEvaluate(Parser parser, String functionName, List<Object> parameters)

--- a/src/main/java/net/rptools/parser/function/impl/Addition.java
+++ b/src/main/java/net/rptools/parser/function/impl/Addition.java
@@ -34,12 +34,11 @@ public class Addition extends AbstractFunction {
       return parameters.get(0);
     } else {
 
-      if (containsString(parameters)) {
+      if (!containsOnlyBigDecimals(parameters)) {
         StringBuilder sb = new StringBuilder();
         for (Object param : parameters) {
           sb.append(param.toString());
         }
-
         return sb.toString();
       } else {
         BigDecimal total = new BigDecimal(0);
@@ -52,20 +51,6 @@ public class Addition extends AbstractFunction {
 
         return total;
       }
-    }
-  }
-
-  @Override
-  public void checkParameters(String functionName, List<Object> parameters)
-      throws ParameterException {
-    super.checkParameters(functionName, parameters);
-
-    for (Object param : parameters) {
-      if (!(param instanceof BigDecimal || param instanceof String))
-        throw new ParameterException(
-            String.format(
-                "Illegal argument type %s, expecting %s or %s",
-                param.getClass().getName(), BigDecimal.class.getName(), String.class.getName()));
     }
   }
 }

--- a/src/main/java/net/rptools/parser/function/impl/Equals.java
+++ b/src/main/java/net/rptools/parser/function/impl/Equals.java
@@ -31,7 +31,7 @@ public class Equals extends AbstractFunction {
       throws EvaluationException, ParameterException {
     boolean value = true;
 
-    if (containsString(parameters)) {
+    if (!containsOnlyBigDecimals(parameters)) {
       for (int i = 0; i < parameters.size() - 1; i++) {
         String s1 = parameters.get(i).toString();
         String s2 = parameters.get(i + 1).toString();
@@ -51,19 +51,5 @@ public class Equals extends AbstractFunction {
     }
 
     return value ? BigDecimal.ONE : BigDecimal.ZERO;
-  }
-
-  @Override
-  public void checkParameters(String functionName, List<Object> parameters)
-      throws ParameterException {
-    super.checkParameters(functionName, parameters);
-
-    for (Object param : parameters) {
-      if (!(param instanceof BigDecimal || param instanceof String))
-        throw new ParameterException(
-            String.format(
-                "Illegal argument type %s, expecting %s or %s",
-                param.getClass().getName(), BigDecimal.class.getName(), String.class.getName()));
-    }
   }
 }

--- a/src/main/java/net/rptools/parser/function/impl/NotEquals.java
+++ b/src/main/java/net/rptools/parser/function/impl/NotEquals.java
@@ -31,7 +31,7 @@ public class NotEquals extends AbstractFunction {
       throws EvaluationException, ParameterException {
     boolean value = true;
 
-    if (containsString(parameters)) {
+    if (!containsOnlyBigDecimals(parameters)) {
       for (int i = 0; i < parameters.size() - 1; i++) {
         String s1 = parameters.get(i).toString();
         String s2 = parameters.get(i + 1).toString();
@@ -48,19 +48,5 @@ public class NotEquals extends AbstractFunction {
     }
 
     return value ? BigDecimal.ONE : BigDecimal.ZERO;
-  }
-
-  @Override
-  public void checkParameters(String functionName, List<Object> parameters)
-      throws ParameterException {
-    super.checkParameters(functionName, parameters);
-
-    for (Object param : parameters) {
-      if (!(param instanceof BigDecimal || param instanceof String))
-        throw new ParameterException(
-            String.format(
-                "Illegal argument type %s, expecting %s or %s",
-                param.getClass().getName(), BigDecimal.class.getName(), String.class.getName()));
-    }
   }
 }

--- a/src/main/java/net/rptools/parser/function/impl/StrEquals.java
+++ b/src/main/java/net/rptools/parser/function/impl/StrEquals.java
@@ -31,27 +31,21 @@ public class StrEquals extends AbstractFunction {
       throws EvaluationException, ParameterException {
     boolean value = true;
 
-    for (int i = 0; i < parameters.size() - 1; i++) {
-      String s1 = parameters.get(i).toString();
-      String s2 = parameters.get(i + 1).toString();
+    if (!containsOnlyBigDecimals(parameters)) {
+      for (int i = 0; i < parameters.size() - 1; i++) {
+        String s1 = parameters.get(i).toString();
+        String s2 = parameters.get(i + 1).toString();
+        value &= s1.trim().equals(s2.trim());
+      }
+    } else {
+      for (int i = 0; i < parameters.size() - 1; i++) {
+        BigDecimal d1 = (BigDecimal) parameters.get(i);
+        BigDecimal d2 = (BigDecimal) parameters.get(i + 1);
 
-      value &= s1.equals(s2);
+        value &= (d1.compareTo(d2) == 0);
+      }
     }
 
     return value ? BigDecimal.ONE : BigDecimal.ZERO;
-  }
-
-  @Override
-  public void checkParameters(String functionName, List<Object> parameters)
-      throws ParameterException {
-    super.checkParameters(functionName, parameters);
-
-    for (Object param : parameters) {
-      if (!(param instanceof String))
-        throw new ParameterException(
-            String.format(
-                "Illegal argument type %s, expecting %s",
-                param.getClass().getName(), String.class.getName()));
-    }
   }
 }

--- a/src/main/java/net/rptools/parser/function/impl/StrNotEquals.java
+++ b/src/main/java/net/rptools/parser/function/impl/StrNotEquals.java
@@ -31,12 +31,11 @@ public class StrNotEquals extends AbstractFunction {
       throws EvaluationException, ParameterException {
     boolean value = true;
 
-    if (containsString(parameters)) {
+    if (!containsOnlyBigDecimals(parameters)) {
       for (int i = 0; i < parameters.size() - 1; i++) {
         String s1 = parameters.get(i).toString();
         String s2 = parameters.get(i + 1).toString();
-
-        value &= !s1.trim().equalsIgnoreCase(s2.trim());
+        value &= !s1.trim().equals(s2.trim());
       }
     } else {
       for (int i = 0; i < parameters.size() - 1; i++) {
@@ -48,19 +47,5 @@ public class StrNotEquals extends AbstractFunction {
     }
 
     return value ? BigDecimal.ONE : BigDecimal.ZERO;
-  }
-
-  @Override
-  public void checkParameters(String functionName, List<Object> parameters)
-      throws ParameterException {
-    super.checkParameters(functionName, parameters);
-
-    for (Object param : parameters) {
-      if (!(param instanceof BigDecimal || param instanceof String))
-        throw new ParameterException(
-            String.format(
-                "Illegal argument type %s, expecting %s or %s",
-                param.getClass().getName(), BigDecimal.class.getName(), String.class.getName()));
-    }
   }
 }

--- a/src/test/java/net/rptools/parser/ParserTest.java
+++ b/src/test/java/net/rptools/parser/ParserTest.java
@@ -25,6 +25,31 @@ import net.rptools.parser.function.ParameterException;
 
 public class ParserTest extends TestCase {
 
+  public void testIncompatibleArgumentOperations() throws ParserException {
+
+    VariableResolver resolver = new MapVariableResolver();
+    Parser p = new Parser(resolver, true);
+
+    // string + object
+    resolver.setVariable("x", List.of("one", "two"));
+    evaluateStringExpression(p, "\"text\" + x", "text[one, two]");
+
+    // num + object
+    evaluateStringExpression(p, "1 + x", "1[one, two]");
+
+    // string equals (case ignore) object
+    evaluateExpression(p, "'[one, two]' == x", BigDecimal.ONE);
+
+    // string equals (case ignore) object
+    evaluateExpression(p, "'[one, three]' != x", BigDecimal.ONE);
+
+    // string equals (strict) object
+    evaluateExpression(p, "eqs('[one, two]',x)", BigDecimal.ONE);
+
+    // string not equals (strict) object
+    evaluateExpression(p, "neqs('[one, TWO]',x)", BigDecimal.ONE);
+  }
+
   public void testParseExpressionSimple() throws ParserException {
     Parser p = new Parser();
     Expression xp = p.parseExpression("1+2");


### PR DESCRIPTION
Makes these operators backwards compatible when expressions use java objects (like json in MapTool), e.g.

[r: "test" + json.set("{}", "property", "value")]

Add unit tests for simple string + object combinations

Upgrade gradle

fixes #1898

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/parser/42)
<!-- Reviewable:end -->
