### PR TITLE
Refactor Parser to separate expression parsing from evaluation. 

### DIFF
--- a/src/main/java/net/rptools/parser/EvaluationTreeParser.java
+++ b/src/main/java/net/rptools/parser/EvaluationTreeParser.java
@@ -45,7 +45,7 @@ public class EvaluationTreeParser {
     this.parser = parser;
   }
 
-  public Object evaluate(AST node) throws ParserException {
+  public Object evaluate(AST node, VariableResolver resolver) throws ParserException {
     AST child;
 
     switch (node.getType()) {
@@ -82,9 +82,9 @@ public class EvaluationTreeParser {
 
           child = node.getFirstChild();
           if (child != null) {
-            params.add(evaluate(child));
+            params.add(evaluate(child, resolver));
             while ((child = child.getNextSibling()) != null) {
-              params.add(evaluate(child));
+              params.add(evaluate(child, resolver));
             }
           }
 
@@ -92,7 +92,7 @@ public class EvaluationTreeParser {
           if (function == null) {
             throw new EvaluationException(String.format("Undefined unary function: %s", name));
           }
-          return function.evaluate(parser, name, params);
+          return function.evaluate(parser, resolver, name, params);
         }
       case OPERATOR:
       case FUNCTION:
@@ -106,9 +106,9 @@ public class EvaluationTreeParser {
 
           child = node.getFirstChild();
           if (child != null) {
-            params.add(evaluate(child));
+            params.add(evaluate(child, resolver));
             while ((child = child.getNextSibling()) != null) {
-              params.add(evaluate(child));
+              params.add(evaluate(child, resolver));
             }
           }
 
@@ -116,15 +116,15 @@ public class EvaluationTreeParser {
           if (function == null) {
             throw new EvaluationException(String.format("Undefined function: %s", name));
           }
-          return function.evaluate(parser, name, params);
+          return function.evaluate(parser, resolver, name, params);
         }
       case VARIABLE:
         {
           String name = node.getText();
-          if (!parser.containsVariable(name, VariableModifiers.None)) {
+          if (!resolver.containsVariable(name, VariableModifiers.None)) {
             throw new EvaluationException(String.format("Undefined variable: %s", name));
           }
-          Object value = parser.getVariable(node.getText(), VariableModifiers.None);
+          Object value = resolver.getVariable(node.getText(), VariableModifiers.None);
           if (log.isLoggable(Level.FINEST))
             log.finest(String.format("VARIABLE: name=%s, value=%s\n", node.getText(), value));
           return value;
@@ -132,10 +132,10 @@ public class EvaluationTreeParser {
       case PROMPTVARIABLE:
         {
           String name = node.getText();
-          if (!parser.containsVariable(name, VariableModifiers.Prompt)) {
+          if (!resolver.containsVariable(name, VariableModifiers.Prompt)) {
             throw new EvaluationException(String.format("Undefined variable: %s", name));
           }
-          Object value = parser.getVariable(node.getText(), VariableModifiers.Prompt);
+          Object value = resolver.getVariable(node.getText(), VariableModifiers.Prompt);
           if (log.isLoggable(Level.FINEST))
             log.finest(String.format("VARIABLE: name=%s, value=%s\n", node.getText(), value));
           return value;

--- a/src/main/java/net/rptools/parser/InlineTreeFormatter.java
+++ b/src/main/java/net/rptools/parser/InlineTreeFormatter.java
@@ -19,8 +19,6 @@ import static net.rptools.parser.ExpressionParserTokenTypes.*;
 import antlr.collections.AST;
 import java.util.HashMap;
 import java.util.Map;
-import net.rptools.parser.function.EvaluationException;
-import net.rptools.parser.function.ParameterException;
 
 public class InlineTreeFormatter {
 
@@ -47,7 +45,7 @@ public class InlineTreeFormatter {
     ORDER_OF_OPERATIONS.put("||", 13);
   }
 
-  public String format(AST node) throws EvaluationException, ParameterException {
+  public String format(AST node) {
     StringBuilder sb = new StringBuilder();
     format(node, sb);
 
@@ -60,7 +58,7 @@ public class InlineTreeFormatter {
     return result == null ? Integer.MAX_VALUE : result;
   }
 
-  private void format(AST node, StringBuilder sb) throws EvaluationException, ParameterException {
+  private void format(AST node, StringBuilder sb) {
     if (node == null) return;
 
     switch (node.getType()) {
@@ -119,7 +117,7 @@ public class InlineTreeFormatter {
           return;
         }
       default:
-        throw new EvaluationException(
+        throw new IllegalArgumentException(
             String.format("Unknown node type: name=%s, type=%d", node.getText(), node.getType()));
     }
   }

--- a/src/main/java/net/rptools/parser/Parser.java
+++ b/src/main/java/net/rptools/parser/Parser.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import net.rptools.CaseInsensitiveHashMap;
 import net.rptools.parser.function.Function;
 import net.rptools.parser.function.impl.AbsoluteValue;
@@ -63,14 +62,12 @@ import net.rptools.parser.function.impl.StrNotEquals;
 import net.rptools.parser.function.impl.Subtraction;
 import net.rptools.parser.transform.Transformer;
 
-public class Parser implements VariableResolver {
-  private final Map<String, Function> functions = new CaseInsensitiveHashMap<Function>();
+public class Parser {
+  private final Map<String, Function> functions = new CaseInsensitiveHashMap<>();
 
-  private final List<Transformer> transforms = new ArrayList<Transformer>();
+  private final List<Transformer> transforms = new ArrayList<>();
 
   private final EvaluationTreeParser evaluationTreeParser;
-
-  private final VariableResolver variableResolver;
 
   ///////////////////////////////////////////////////////////////////////////
   // Constructor(s)
@@ -81,10 +78,6 @@ public class Parser implements VariableResolver {
   }
 
   public Parser(boolean addDefaultFunctions) {
-    this(null, addDefaultFunctions);
-  }
-
-  public Parser(VariableResolver variableResolver, boolean addDefaultFunctions) {
 
     if (addDefaultFunctions) {
       addStandardOperators();
@@ -95,9 +88,6 @@ public class Parser implements VariableResolver {
     }
 
     this.evaluationTreeParser = new EvaluationTreeParser(this);
-
-    if (variableResolver == null) this.variableResolver = new MapVariableResolver();
-    else this.variableResolver = variableResolver;
   }
 
   ///////////////////////////////////////////////////////////////////////////
@@ -197,44 +187,6 @@ public class Parser implements VariableResolver {
     }
 
     return s;
-  }
-
-  ///////////////////////////////////////////////////////////////////////////
-  // Variable
-  ///////////////////////////////////////////////////////////////////////////
-
-  public VariableResolver getVariableResolver() {
-    return variableResolver;
-  }
-
-  public boolean containsVariable(String name) throws ParserException {
-    return variableResolver.containsVariable(name, VariableModifiers.None);
-  }
-
-  public void setVariable(String name, Object value) throws ParserException {
-    variableResolver.setVariable(name, VariableModifiers.None, value);
-  }
-
-  public Object getVariable(String variableName) throws ParserException {
-    return variableResolver.getVariable(variableName, VariableModifiers.None);
-  }
-
-  public boolean containsVariable(String name, VariableModifiers vType) throws ParserException {
-    return variableResolver.containsVariable(name, vType);
-  }
-
-  public void setVariable(String name, VariableModifiers vType, Object value)
-      throws ParserException {
-    variableResolver.setVariable(name, vType, value);
-  }
-
-  public Object getVariable(String variableName, VariableModifiers vType) throws ParserException {
-    return variableResolver.getVariable(variableName, vType);
-  }
-
-  @Override
-  public Set<String> getVariables() {
-    return variableResolver.getVariables();
   }
 
   public EvaluationTreeParser getEvaluationTreeParser() throws ParserException {

--- a/src/main/java/net/rptools/parser/function/AbstractFunction.java
+++ b/src/main/java/net/rptools/parser/function/AbstractFunction.java
@@ -18,6 +18,7 @@ import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.parser.Parser;
 import net.rptools.parser.ParserException;
+import net.rptools.parser.VariableResolver;
 
 public abstract class AbstractFunction implements Function {
   private final String[] aliases;
@@ -54,11 +55,12 @@ public abstract class AbstractFunction implements Function {
     return aliases;
   }
 
-  public final Object evaluate(Parser parser, String functionName, List<Object> parameters)
+  public final Object evaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws ParserException {
     checkParameters(functionName, parameters);
 
-    return childEvaluate(parser, functionName, parameters);
+    return childEvaluate(parser, resolver, functionName, parameters);
   }
 
   public final int getMinimumParameterCount() {
@@ -105,6 +107,7 @@ public abstract class AbstractFunction implements Function {
     return true;
   }
 
-  public abstract Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public abstract Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws ParserException;
 }

--- a/src/main/java/net/rptools/parser/function/Function.java
+++ b/src/main/java/net/rptools/parser/function/Function.java
@@ -17,13 +17,15 @@ package net.rptools.parser.function;
 import java.util.List;
 import net.rptools.parser.Parser;
 import net.rptools.parser.ParserException;
+import net.rptools.parser.VariableResolver;
 
 public interface Function {
   public static final int UNLIMITED_PARAMETERS = -1;
 
   public String[] getAliases();
 
-  public Object evaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object evaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws ParserException;
 
   public void checkParameters(String functionName, List<Object> parameters)

--- a/src/main/java/net/rptools/parser/function/impl/AbsoluteValue.java
+++ b/src/main/java/net/rptools/parser/function/impl/AbsoluteValue.java
@@ -17,6 +17,7 @@ package net.rptools.parser.function.impl;
 import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 
 public class AbsoluteValue extends AbstractNumberFunction {
@@ -25,7 +26,8 @@ public class AbsoluteValue extends AbstractNumberFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters) {
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters) {
     BigDecimal value = (BigDecimal) parameters.get(0);
 
     return value.abs();

--- a/src/main/java/net/rptools/parser/function/impl/Addition.java
+++ b/src/main/java/net/rptools/parser/function/impl/Addition.java
@@ -17,6 +17,7 @@ package net.rptools.parser.function.impl;
 import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractFunction;
 import net.rptools.parser.function.EvaluationException;
 import net.rptools.parser.function.ParameterException;
@@ -27,7 +28,8 @@ public class Addition extends AbstractFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException, ParameterException {
     if (parameters.size() == 1) {
       // unary usage

--- a/src/main/java/net/rptools/parser/function/impl/And.java
+++ b/src/main/java/net/rptools/parser/function/impl/And.java
@@ -16,6 +16,7 @@ package net.rptools.parser.function.impl;
 
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractLogicalOperatorFunction;
 import net.rptools.parser.function.EvaluationException;
 import net.rptools.parser.function.ParameterException;
@@ -26,7 +27,8 @@ public class And extends AbstractLogicalOperatorFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException, ParameterException {
     boolean value = true;
 

--- a/src/main/java/net/rptools/parser/function/impl/Assignment.java
+++ b/src/main/java/net/rptools/parser/function/impl/Assignment.java
@@ -17,6 +17,7 @@ package net.rptools.parser.function.impl;
 import java.util.List;
 import net.rptools.parser.Parser;
 import net.rptools.parser.ParserException;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractFunction;
 
 public class Assignment extends AbstractFunction {
@@ -25,14 +26,15 @@ public class Assignment extends AbstractFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws ParserException {
 
     String name = (String) parameters.get(0);
 
     Object value = parameters.get(1);
 
-    parser.setVariable(name, value);
+    resolver.setVariable(name, value);
 
     return value;
   }

--- a/src/main/java/net/rptools/parser/function/impl/BitwiseAnd.java
+++ b/src/main/java/net/rptools/parser/function/impl/BitwiseAnd.java
@@ -18,6 +18,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 import net.rptools.parser.function.EvaluationException;
 import net.rptools.parser.function.ParameterException;
@@ -28,7 +29,8 @@ public class BitwiseAnd extends AbstractNumberFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException, ParameterException {
     BigInteger value = null;
 

--- a/src/main/java/net/rptools/parser/function/impl/BitwiseNot.java
+++ b/src/main/java/net/rptools/parser/function/impl/BitwiseNot.java
@@ -18,6 +18,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 import net.rptools.parser.function.EvaluationException;
 import net.rptools.parser.function.ParameterException;
@@ -28,7 +29,8 @@ public class BitwiseNot extends AbstractNumberFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException, ParameterException {
     BigInteger value = ((BigDecimal) parameters.get(0)).toBigInteger();
 

--- a/src/main/java/net/rptools/parser/function/impl/BitwiseOr.java
+++ b/src/main/java/net/rptools/parser/function/impl/BitwiseOr.java
@@ -18,6 +18,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 import net.rptools.parser.function.EvaluationException;
 import net.rptools.parser.function.ParameterException;
@@ -28,7 +29,8 @@ public class BitwiseOr extends AbstractNumberFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException, ParameterException {
     BigInteger value = null;
 

--- a/src/main/java/net/rptools/parser/function/impl/BitwiseXor.java
+++ b/src/main/java/net/rptools/parser/function/impl/BitwiseXor.java
@@ -18,6 +18,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 import net.rptools.parser.function.EvaluationException;
 import net.rptools.parser.function.ParameterException;
@@ -28,7 +29,8 @@ public class BitwiseXor extends AbstractNumberFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException, ParameterException {
     BigInteger value = null;
 

--- a/src/main/java/net/rptools/parser/function/impl/Ceiling.java
+++ b/src/main/java/net/rptools/parser/function/impl/Ceiling.java
@@ -17,6 +17,7 @@ package net.rptools.parser.function.impl;
 import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 import net.rptools.parser.function.EvaluationException;
 import net.rptools.parser.function.ParameterException;
@@ -27,7 +28,8 @@ public class Ceiling extends AbstractNumberFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException, ParameterException {
     BigDecimal value = (BigDecimal) parameters.get(0);
     return new BigDecimal(Math.ceil(value.doubleValue()));

--- a/src/main/java/net/rptools/parser/function/impl/Division.java
+++ b/src/main/java/net/rptools/parser/function/impl/Division.java
@@ -18,6 +18,7 @@ import java.math.BigDecimal;
 import java.math.MathContext;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 import net.rptools.parser.function.EvaluationException;
 import net.rptools.parser.function.ParameterException;
@@ -28,7 +29,8 @@ public class Division extends AbstractNumberFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException, ParameterException {
     BigDecimal total = null;
     boolean first = true;

--- a/src/main/java/net/rptools/parser/function/impl/Equals.java
+++ b/src/main/java/net/rptools/parser/function/impl/Equals.java
@@ -17,6 +17,7 @@ package net.rptools.parser.function.impl;
 import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractFunction;
 import net.rptools.parser.function.EvaluationException;
 import net.rptools.parser.function.ParameterException;
@@ -27,7 +28,8 @@ public class Equals extends AbstractFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException, ParameterException {
     boolean value = true;
 

--- a/src/main/java/net/rptools/parser/function/impl/Eval.java
+++ b/src/main/java/net/rptools/parser/function/impl/Eval.java
@@ -18,16 +18,19 @@ import java.util.List;
 import net.rptools.parser.Expression;
 import net.rptools.parser.Parser;
 import net.rptools.parser.ParserException;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractFunction;
 import net.rptools.parser.function.ParameterException;
 
 public class Eval extends AbstractFunction {
+
   public Eval() {
     super(1, -1, "eval");
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws ParserException {
 
     Object ret = null;
@@ -42,7 +45,7 @@ public class Eval extends AbstractFunction {
         throw new ParameterException(String.format("Unable to evaluate expression %s", x));
       }
 
-      ret = expression.evaluate();
+      ret = expression.evaluate(resolver);
     }
 
     return ret;

--- a/src/main/java/net/rptools/parser/function/impl/Floor.java
+++ b/src/main/java/net/rptools/parser/function/impl/Floor.java
@@ -17,6 +17,7 @@ package net.rptools.parser.function.impl;
 import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 import net.rptools.parser.function.EvaluationException;
 import net.rptools.parser.function.ParameterException;
@@ -27,7 +28,8 @@ public class Floor extends AbstractNumberFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException, ParameterException {
     BigDecimal value = (BigDecimal) parameters.get(0);
     return new BigDecimal(Math.floor(value.doubleValue()));

--- a/src/main/java/net/rptools/parser/function/impl/Greater.java
+++ b/src/main/java/net/rptools/parser/function/impl/Greater.java
@@ -17,6 +17,7 @@ package net.rptools.parser.function.impl;
 import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 import net.rptools.parser.function.EvaluationException;
 import net.rptools.parser.function.ParameterException;
@@ -27,7 +28,8 @@ public class Greater extends AbstractNumberFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException, ParameterException {
     boolean value = true;
 

--- a/src/main/java/net/rptools/parser/function/impl/GreaterOrEqual.java
+++ b/src/main/java/net/rptools/parser/function/impl/GreaterOrEqual.java
@@ -17,6 +17,7 @@ package net.rptools.parser.function.impl;
 import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 import net.rptools.parser.function.EvaluationException;
 import net.rptools.parser.function.ParameterException;
@@ -27,7 +28,8 @@ public class GreaterOrEqual extends AbstractNumberFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException, ParameterException {
     boolean value = true;
 

--- a/src/main/java/net/rptools/parser/function/impl/Hex.java
+++ b/src/main/java/net/rptools/parser/function/impl/Hex.java
@@ -18,6 +18,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 import net.rptools.parser.function.EvaluationException;
 import net.rptools.parser.function.ParameterException;
@@ -28,7 +29,8 @@ public class Hex extends AbstractNumberFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException, ParameterException {
 
     BigInteger value = ((BigDecimal) parameters.get(0)).toBigInteger();

--- a/src/main/java/net/rptools/parser/function/impl/Hypotenuse.java
+++ b/src/main/java/net/rptools/parser/function/impl/Hypotenuse.java
@@ -17,6 +17,7 @@ package net.rptools.parser.function.impl;
 import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 import net.rptools.parser.function.EvaluationException;
 import net.rptools.parser.function.ParameterException;
@@ -27,7 +28,8 @@ public class Hypotenuse extends AbstractNumberFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException, ParameterException {
     BigDecimal value1 = (BigDecimal) parameters.get(0);
     BigDecimal value2 = (BigDecimal) parameters.get(1);

--- a/src/main/java/net/rptools/parser/function/impl/Lesser.java
+++ b/src/main/java/net/rptools/parser/function/impl/Lesser.java
@@ -17,6 +17,7 @@ package net.rptools.parser.function.impl;
 import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 import net.rptools.parser.function.EvaluationException;
 import net.rptools.parser.function.ParameterException;
@@ -27,7 +28,8 @@ public class Lesser extends AbstractNumberFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException, ParameterException {
     boolean value = true;
 

--- a/src/main/java/net/rptools/parser/function/impl/LesserEqual.java
+++ b/src/main/java/net/rptools/parser/function/impl/LesserEqual.java
@@ -17,6 +17,7 @@ package net.rptools.parser.function.impl;
 import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 import net.rptools.parser.function.EvaluationException;
 import net.rptools.parser.function.ParameterException;
@@ -27,7 +28,8 @@ public class LesserEqual extends AbstractNumberFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException, ParameterException {
     boolean value = true;
 

--- a/src/main/java/net/rptools/parser/function/impl/Ln.java
+++ b/src/main/java/net/rptools/parser/function/impl/Ln.java
@@ -17,6 +17,7 @@ package net.rptools.parser.function.impl;
 import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 import net.rptools.parser.function.EvaluationException;
 import net.rptools.parser.function.ParameterException;
@@ -28,7 +29,8 @@ public class Ln extends AbstractNumberFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException, ParameterException {
     BigDecimal value = (BigDecimal) parameters.get(0);
 

--- a/src/main/java/net/rptools/parser/function/impl/Log.java
+++ b/src/main/java/net/rptools/parser/function/impl/Log.java
@@ -17,6 +17,7 @@ package net.rptools.parser.function.impl;
 import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 import net.rptools.parser.function.EvaluationException;
 import net.rptools.parser.function.ParameterException;
@@ -28,7 +29,8 @@ public class Log extends AbstractNumberFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException, ParameterException {
     BigDecimal value = (BigDecimal) parameters.get(0);
 

--- a/src/main/java/net/rptools/parser/function/impl/Max.java
+++ b/src/main/java/net/rptools/parser/function/impl/Max.java
@@ -17,6 +17,7 @@ package net.rptools.parser.function.impl;
 import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 import net.rptools.parser.function.EvaluationException;
 import net.rptools.parser.function.ParameterException;
@@ -27,7 +28,8 @@ public class Max extends AbstractNumberFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException, ParameterException {
     BigDecimal result = null;
     boolean first = true;

--- a/src/main/java/net/rptools/parser/function/impl/Mean.java
+++ b/src/main/java/net/rptools/parser/function/impl/Mean.java
@@ -18,6 +18,7 @@ import java.math.BigDecimal;
 import java.math.MathContext;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractFunction;
 import net.rptools.parser.function.EvaluationException;
 import net.rptools.parser.function.ParameterException;
@@ -28,7 +29,8 @@ public class Mean extends AbstractFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException, ParameterException {
     if (parameters.size() == 1) {
       // unary usage

--- a/src/main/java/net/rptools/parser/function/impl/Median.java
+++ b/src/main/java/net/rptools/parser/function/impl/Median.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractFunction;
 import net.rptools.parser.function.EvaluationException;
 import net.rptools.parser.function.ParameterException;
@@ -30,7 +31,8 @@ public class Median extends AbstractFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException, ParameterException {
     if (parameters.size() == 1) {
       // unary usage

--- a/src/main/java/net/rptools/parser/function/impl/Min.java
+++ b/src/main/java/net/rptools/parser/function/impl/Min.java
@@ -17,6 +17,7 @@ package net.rptools.parser.function.impl;
 import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 import net.rptools.parser.function.EvaluationException;
 import net.rptools.parser.function.ParameterException;
@@ -27,7 +28,8 @@ public class Min extends AbstractNumberFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException, ParameterException {
     BigDecimal result = null;
     boolean first = true;

--- a/src/main/java/net/rptools/parser/function/impl/Multiplication.java
+++ b/src/main/java/net/rptools/parser/function/impl/Multiplication.java
@@ -17,6 +17,7 @@ package net.rptools.parser.function.impl;
 import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 import net.rptools.parser.function.EvaluationException;
 import net.rptools.parser.function.ParameterException;
@@ -27,7 +28,8 @@ public class Multiplication extends AbstractNumberFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException, ParameterException {
     BigDecimal total = BigDecimal.ONE;
 

--- a/src/main/java/net/rptools/parser/function/impl/Not.java
+++ b/src/main/java/net/rptools/parser/function/impl/Not.java
@@ -16,6 +16,7 @@ package net.rptools.parser.function.impl;
 
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractLogicalOperatorFunction;
 import net.rptools.parser.function.EvaluationException;
 import net.rptools.parser.function.ParameterException;
@@ -26,7 +27,8 @@ public class Not extends AbstractLogicalOperatorFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException, ParameterException {
     return BooleanAsBigDecimal(!ConvertToBoolean(parameters.get(0)));
   }

--- a/src/main/java/net/rptools/parser/function/impl/NotEquals.java
+++ b/src/main/java/net/rptools/parser/function/impl/NotEquals.java
@@ -17,6 +17,7 @@ package net.rptools.parser.function.impl;
 import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractFunction;
 import net.rptools.parser.function.EvaluationException;
 import net.rptools.parser.function.ParameterException;
@@ -27,7 +28,8 @@ public class NotEquals extends AbstractFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException, ParameterException {
     boolean value = true;
 

--- a/src/main/java/net/rptools/parser/function/impl/Or.java
+++ b/src/main/java/net/rptools/parser/function/impl/Or.java
@@ -16,6 +16,7 @@ package net.rptools.parser.function.impl;
 
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractLogicalOperatorFunction;
 import net.rptools.parser.function.EvaluationException;
 import net.rptools.parser.function.ParameterException;
@@ -26,7 +27,8 @@ public class Or extends AbstractLogicalOperatorFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException, ParameterException {
     boolean value = false;
 

--- a/src/main/java/net/rptools/parser/function/impl/Power.java
+++ b/src/main/java/net/rptools/parser/function/impl/Power.java
@@ -18,6 +18,7 @@ import java.math.BigDecimal;
 import java.math.MathContext;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 import net.rptools.parser.function.EvaluationException;
 import net.rptools.parser.function.ParameterException;
@@ -30,7 +31,8 @@ public class Power extends AbstractNumberFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException, ParameterException {
     BigDecimal value = (BigDecimal) parameters.get(0);
 

--- a/src/main/java/net/rptools/parser/function/impl/Round.java
+++ b/src/main/java/net/rptools/parser/function/impl/Round.java
@@ -18,6 +18,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 import net.rptools.parser.function.EvaluationException;
 import net.rptools.parser.function.ParameterException;
@@ -28,7 +29,8 @@ public class Round extends AbstractNumberFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException, ParameterException {
     int precision = 0;
 

--- a/src/main/java/net/rptools/parser/function/impl/SquareRoot.java
+++ b/src/main/java/net/rptools/parser/function/impl/SquareRoot.java
@@ -17,6 +17,7 @@ package net.rptools.parser.function.impl;
 import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 import net.rptools.parser.function.EvaluationException;
 import net.rptools.parser.function.ParameterException;
@@ -30,7 +31,8 @@ public class SquareRoot extends AbstractNumberFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException, ParameterException {
     int scale = DEFAULT_SCALE;
     if (parameters.size() == 2) {

--- a/src/main/java/net/rptools/parser/function/impl/StrEquals.java
+++ b/src/main/java/net/rptools/parser/function/impl/StrEquals.java
@@ -17,6 +17,7 @@ package net.rptools.parser.function.impl;
 import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractFunction;
 import net.rptools.parser.function.EvaluationException;
 import net.rptools.parser.function.ParameterException;
@@ -27,7 +28,8 @@ public class StrEquals extends AbstractFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException, ParameterException {
     boolean value = true;
 

--- a/src/main/java/net/rptools/parser/function/impl/StrNotEquals.java
+++ b/src/main/java/net/rptools/parser/function/impl/StrNotEquals.java
@@ -17,6 +17,7 @@ package net.rptools.parser.function.impl;
 import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractFunction;
 import net.rptools.parser.function.EvaluationException;
 import net.rptools.parser.function.ParameterException;
@@ -27,7 +28,8 @@ public class StrNotEquals extends AbstractFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException, ParameterException {
     boolean value = true;
 

--- a/src/main/java/net/rptools/parser/function/impl/Subtraction.java
+++ b/src/main/java/net/rptools/parser/function/impl/Subtraction.java
@@ -17,6 +17,7 @@ package net.rptools.parser.function.impl;
 import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 import net.rptools.parser.function.EvaluationException;
 import net.rptools.parser.function.ParameterException;
@@ -27,7 +28,8 @@ public class Subtraction extends AbstractNumberFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException, ParameterException {
     if (parameters.size() == 1) {
       // unary usage

--- a/src/test/java/net/rptools/parser/DeterministicTreeParserTest.java
+++ b/src/test/java/net/rptools/parser/DeterministicTreeParserTest.java
@@ -27,7 +27,7 @@ public class DeterministicTreeParserTest extends TestCase {
       throws ParserException, EvaluationException, ParameterException {
     Parser p = new Parser();
     Expression xp = p.parseExpression("200+2+2*2");
-    Expression dxp = xp.getDeterministicExpression();
+    Expression dxp = xp.getDeterministicExpression(new MapVariableResolver());
 
     assertSame(xp, dxp);
 
@@ -42,7 +42,7 @@ public class DeterministicTreeParserTest extends TestCase {
     p.addFunction(new NonDeterministicFunction());
 
     Expression xp = p.parseExpression("200+2+nondeterministic(2, 2)+sum(1+2,2,3)");
-    Expression dxp = xp.getDeterministicExpression();
+    Expression dxp = xp.getDeterministicExpression(new MapVariableResolver());
 
     assertNotSame(xp, dxp);
 
@@ -61,7 +61,7 @@ public class DeterministicTreeParserTest extends TestCase {
     assertEquals(
         " ( = a ( + ( + 200 2 ) ( nondeterministic 2 2 ) ) )", xp.getTree().toStringTree());
 
-    Expression dxp = xp.getDeterministicExpression();
+    Expression dxp = xp.getDeterministicExpression(new MapVariableResolver());
 
     assertNotSame(xp, dxp);
 
@@ -74,7 +74,7 @@ public class DeterministicTreeParserTest extends TestCase {
 
     Expression xp = p.parseExpression("100+nondeterministic(4, 1)*10");
 
-    Expression dxp = xp.getDeterministicExpression();
+    Expression dxp = xp.getDeterministicExpression(new MapVariableResolver());
 
     assertNotSame(xp, dxp);
 
@@ -84,10 +84,12 @@ public class DeterministicTreeParserTest extends TestCase {
 
   public void testEvaluate_VariableResolution() throws ParserException {
     Parser p = new Parser();
-    p.setVariable("simpleInt", new BigDecimal(10));
+    VariableResolver r = new MapVariableResolver();
+
+    r.setVariable("simpleInt", new BigDecimal(10));
 
     Expression xp = p.parseExpression("1+simpleInt");
-    Expression dxp = xp.getDeterministicExpression();
+    Expression dxp = xp.getDeterministicExpression(r);
 
     assertNotSame(xp, dxp);
 
@@ -105,7 +107,8 @@ public class DeterministicTreeParserTest extends TestCase {
     }
 
     @Override
-    public Object childEvaluate(Parser parser, String functionName, List<Object> parameters) {
+    public Object childEvaluate(
+        Parser parser, VariableResolver resolver, String functionName, List<Object> parameters) {
       return BigDecimal.ONE;
     }
   }

--- a/src/test/java/net/rptools/parser/function/impl/MeanTest.java
+++ b/src/test/java/net/rptools/parser/function/impl/MeanTest.java
@@ -26,14 +26,17 @@ public class MeanTest extends TestCase {
     Mean mean = new Mean();
 
     assertEquals(
-        new BigDecimal(10), mean.childEvaluate(null, null, createArgs(new BigDecimal(10))));
+        new BigDecimal(10), mean.childEvaluate(null, null, null, createArgs(new BigDecimal(10))));
     assertEquals(
         new BigDecimal(6),
-        mean.childEvaluate(null, null, createArgs(new BigDecimal(10), new BigDecimal(2))));
+        mean.childEvaluate(null, null, null, createArgs(new BigDecimal(10), new BigDecimal(2))));
     assertEquals(
         new BigDecimal(5),
         mean.childEvaluate(
-            null, null, createArgs(new BigDecimal(10), new BigDecimal(2), new BigDecimal(3))));
+            null,
+            null,
+            null,
+            createArgs(new BigDecimal(10), new BigDecimal(2), new BigDecimal(3))));
   }
 
   private List<Object> createArgs(Object... arguments) {

--- a/src/test/java/net/rptools/parser/function/impl/MedianTest.java
+++ b/src/test/java/net/rptools/parser/function/impl/MedianTest.java
@@ -26,17 +26,21 @@ public class MedianTest extends TestCase {
     Median median = new Median();
 
     assertEquals(
-        new BigDecimal(10), median.childEvaluate(null, null, createArgs(new BigDecimal(10))));
+        new BigDecimal(10), median.childEvaluate(null, null, null, createArgs(new BigDecimal(10))));
     assertEquals(
         new BigDecimal(6),
-        median.childEvaluate(null, null, createArgs(new BigDecimal(10), new BigDecimal(2))));
+        median.childEvaluate(null, null, null, createArgs(new BigDecimal(10), new BigDecimal(2))));
     assertEquals(
         new BigDecimal(3),
         median.childEvaluate(
-            null, null, createArgs(new BigDecimal(10), new BigDecimal(2), new BigDecimal(3))));
+            null,
+            null,
+            null,
+            createArgs(new BigDecimal(10), new BigDecimal(2), new BigDecimal(3))));
     assertEquals(
         new BigDecimal(5),
         median.childEvaluate(
+            null,
             null,
             null,
             createArgs(

--- a/src/test/java/net/rptools/parser/function/impl/PowerTest.java
+++ b/src/test/java/net/rptools/parser/function/impl/PowerTest.java
@@ -28,10 +28,10 @@ public class PowerTest extends TestCase {
 
     assertEquals(
         new BigDecimal(100),
-        power.childEvaluate(null, null, createArgs(new BigDecimal(10), new BigDecimal(2))));
+        power.childEvaluate(null, null, null, createArgs(new BigDecimal(10), new BigDecimal(2))));
     assertEquals(
         new BigDecimal("0.1"),
-        power.childEvaluate(null, null, createArgs(new BigDecimal(10), new BigDecimal(-1))));
+        power.childEvaluate(null, null, null, createArgs(new BigDecimal(10), new BigDecimal(-1))));
   }
 
   private List<Object> createArgs(Object... arguments) {


### PR DESCRIPTION
Make VariableResolver an evaluation time argument so clients can re-use Expressions, once parsed, multiple times over.

The key difference is that parser never gets to see the variable resolver and thus doesn't hold on to it, thus the expression doesn't hang on to it transitively either (The expression is bound to the parser). The variableresolver has to be passed in for evaluation. An expression for a given parser can thus be re-used for invocations in loops.

Have a look, I'm creating a caching branch for dicelib and maptool as well. This is not a backwards compatible change.

Fixes #44

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/parser/45)
<!-- Reviewable:end -->
