### PR TITLE
Changes so variables starting with tru / fal will no longer fail

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,8 @@ apply plugin: 'com.diffplug.gradle.spotless'
 apply plugin: 'maven'
 
 
-project.sourceCompatibility = 10
-project.targetCompatibility = 10
+project.sourceCompatibility = 14
+project.targetCompatibility = 14
 
 
 // In this section you declare where to find the dependencies of your project

--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,8 @@ apply plugin: 'com.diffplug.gradle.spotless'
 apply plugin: 'maven'
 
 
-project.sourceCompatibility = 14
-project.targetCompatibility = 14
+project.sourceCompatibility = 10
+project.targetCompatibility = 10
 
 
 // In this section you declare where to find the dependencies of your project

--- a/src/main/antlr/net/rptools/parser/expression.g
+++ b/src/main/antlr/net/rptools/parser/expression.g
@@ -160,7 +160,7 @@ parameterList: (expr (COMMA! expr)* )?
 class ExpressionLexer extends Lexer;
 
 options {
-    k=3;    // needed for newline junk
+    k=5;    // needed for newline junk
     charVocabulary='\u0000'..'\u00FF';  // allow ISO 8859-1
 }
 

--- a/src/main/antlr/net/rptools/parser/expression.g
+++ b/src/main/antlr/net/rptools/parser/expression.g
@@ -156,7 +156,7 @@ parameterList: (expr (COMMA! expr)* )?
 class ExpressionLexer extends Lexer;
 
 options {
-    k=5;    // needed for newline junk
+    k=3;    // needed for newline junk
     charVocabulary='\u0000'..'\u00FF';  // allow ISO 8859-1
 }
 

--- a/src/main/antlr/net/rptools/parser/expression.g
+++ b/src/main/antlr/net/rptools/parser/expression.g
@@ -128,10 +128,6 @@ constantExpression:
                 |
                 HEXNUMBER
                 |
-                TRUE
-                |
-                FALSE
-                |
                 variable
                 |
                 t1:SINGLE_QUOTED_STRING {#t1.setType(STRING);}
@@ -177,8 +173,6 @@ GE		:   ">=" ;
 GT      :   ">" ;
 LT      :   "<" ;
 LE      :   "<=" ;
-TRUE	:  "true";
-FALSE   :  "false";
 
 // Math operators
 PLUS    :   '+' ;

--- a/src/main/java/net/rptools/parser/DeterministicTreeParser.java
+++ b/src/main/java/net/rptools/parser/DeterministicTreeParser.java
@@ -15,14 +15,12 @@
 package net.rptools.parser;
 
 import static net.rptools.parser.ExpressionParserTokenTypes.ASSIGNEE;
-import static net.rptools.parser.ExpressionParserTokenTypes.FALSE;
 import static net.rptools.parser.ExpressionParserTokenTypes.FUNCTION;
 import static net.rptools.parser.ExpressionParserTokenTypes.HEXNUMBER;
 import static net.rptools.parser.ExpressionParserTokenTypes.NUMBER;
 import static net.rptools.parser.ExpressionParserTokenTypes.OPERATOR;
 import static net.rptools.parser.ExpressionParserTokenTypes.PROMPTVARIABLE;
 import static net.rptools.parser.ExpressionParserTokenTypes.STRING;
-import static net.rptools.parser.ExpressionParserTokenTypes.TRUE;
 import static net.rptools.parser.ExpressionParserTokenTypes.UNARY_OPERATOR;
 import static net.rptools.parser.ExpressionParserTokenTypes.VARIABLE;
 
@@ -52,8 +50,6 @@ public class DeterministicTreeParser {
       case NUMBER:
       case HEXNUMBER:
       case ASSIGNEE:
-      case TRUE:
-      case FALSE:
         node.setNextSibling(evaluate(node.getNextSibling(), resolver));
         return node;
       case VARIABLE:

--- a/src/main/java/net/rptools/parser/EvaluationTreeParser.java
+++ b/src/main/java/net/rptools/parser/EvaluationTreeParser.java
@@ -15,14 +15,12 @@
 package net.rptools.parser;
 
 import static net.rptools.parser.ExpressionParserTokenTypes.ASSIGNEE;
-import static net.rptools.parser.ExpressionParserTokenTypes.FALSE;
 import static net.rptools.parser.ExpressionParserTokenTypes.FUNCTION;
 import static net.rptools.parser.ExpressionParserTokenTypes.HEXNUMBER;
 import static net.rptools.parser.ExpressionParserTokenTypes.NUMBER;
 import static net.rptools.parser.ExpressionParserTokenTypes.OPERATOR;
 import static net.rptools.parser.ExpressionParserTokenTypes.PROMPTVARIABLE;
 import static net.rptools.parser.ExpressionParserTokenTypes.STRING;
-import static net.rptools.parser.ExpressionParserTokenTypes.TRUE;
 import static net.rptools.parser.ExpressionParserTokenTypes.UNARY_OPERATOR;
 import static net.rptools.parser.ExpressionParserTokenTypes.VARIABLE;
 
@@ -54,10 +52,6 @@ public class EvaluationTreeParser {
           String name = node.getText();
           return name;
         }
-      case TRUE:
-        return BigDecimal.ONE;
-      case FALSE:
-        return BigDecimal.ZERO;
       case NUMBER:
         {
           BigDecimal d = new BigDecimal(node.getText());

--- a/src/main/java/net/rptools/parser/InlineTreeFormatter.java
+++ b/src/main/java/net/rptools/parser/InlineTreeFormatter.java
@@ -67,8 +67,6 @@ public class InlineTreeFormatter {
       case VARIABLE:
       case NUMBER:
       case HEXNUMBER:
-      case TRUE:
-      case FALSE:
         {
           sb.append(node.getText());
           return;

--- a/src/main/java/net/rptools/parser/MapVariableResolver.java
+++ b/src/main/java/net/rptools/parser/MapVariableResolver.java
@@ -14,6 +14,7 @@
  */
 package net.rptools.parser;
 
+import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -26,11 +27,23 @@ import net.rptools.CaseInsensitiveHashMap;
 public class MapVariableResolver implements VariableResolver {
   private final Map<String, Object> variables = new CaseInsensitiveHashMap<Object>();
 
+  private static final Map<String, Object> constants =
+      Map.of(
+          "true", BigDecimal.ONE,
+          "false", BigDecimal.ZERO);
+
+  public MapVariableResolver() {
+    variables.putAll(constants);
+  }
+
   public boolean containsVariable(String name) throws ParserException {
     return containsVariable(name, VariableModifiers.None);
   }
 
   public void setVariable(String name, Object value) throws ParserException {
+    if (constants.containsKey(name)) {
+      throw new ParserException(name + " can not be the target of assignment.");
+    }
     setVariable(name, VariableModifiers.None, value);
   }
 

--- a/src/test/java/net/rptools/parser/ParserTest.java
+++ b/src/test/java/net/rptools/parser/ParserTest.java
@@ -318,4 +318,24 @@ public class ParserTest extends TestCase {
 
     assertEquals(answer, result);
   }
+
+  public void testAssignToTrue() throws ParserException {
+    Parser p = new Parser();
+    try {
+      evaluateExpression(p, "true = 2", BigDecimal.valueOf(2));
+      fail("Was able to assign to 'true'");
+    } catch (ParserException ex) {
+      // Expected
+    }
+  }
+
+  public void testAssignToFalse() throws ParserException {
+    Parser p = new Parser();
+    try {
+      evaluateExpression(p, "false = 2", BigDecimal.valueOf(2));
+      fail("Was able to assign to 'fakse'");
+    } catch (ParserException ex) {
+      // Expected
+    }
+  }
 }


### PR DESCRIPTION
Its not a 100% fix, for example 
falseSenseOfSecurity = 1 
will still fail... but it's still an improvement over things like falling = 1 failing...

partially fixes RPTools/MapTool#1736

A proper fix would require not tokenising "true"/"false" and having them as parser rules which can make decisions based on context rather than lexer which can not. But this is too big a change at this point in time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/parser/50)
<!-- Reviewable:end -->
