### PR TITLE
Run jitpack build on JDK 21 to match new gradle requirements

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,2 @@
 jdk: 
- - oraclejdk10
+ - oraclejdk21


### PR DESCRIPTION
This is a late follow-up to #81 for #82. Now that the build depends on Java 21, the jitpack build needs to be told to use JDK 21 instead of the old JDK 10.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/parser/89)
<!-- Reviewable:end -->
