### PR TITLE
Support empty function calls and be more particular about successful parses

### DIFF
--- a/src/main/antlr/ExpressionLexer.g4
+++ b/src/main/antlr/ExpressionLexer.g4
@@ -37,6 +37,9 @@ IDENTIFIER           : LETTER (LETTER|DIGIT|'.'|'_')* ;
 SINGLE_QUOTED_STRING : '\'' ( ~'\'' )* '\'' ;
 DOUBLE_QUOTED_STRING : '"' ( ~'"' )* '"' ;
 
+// Force consumption of unknown tokens without discarding them.
+ErrChar : . ;
+
 fragment HEXDIGIT    : ('0'..'9'|'A'..'F'|'a'..'f') ;
 fragment INT         : ('0'..'9')+ ;
 fragment DIGIT       : '0'..'9' ;

--- a/src/main/antlr/ExpressionParser.g4
+++ b/src/main/antlr/ExpressionParser.g4
@@ -22,6 +22,8 @@ options {
     tokenVocab=ExpressionLexer;
 }
 
+full: result=expr (expr)* EOF;
+
 expr:
       id=IDENTIFIER LPAREN (expr (COMMA expr)*)? RPAREN # function
     | QUESTION id=IDENTIFIER  # promptvariable

--- a/src/main/antlr/ExpressionParser.g4
+++ b/src/main/antlr/ExpressionParser.g4
@@ -23,7 +23,7 @@ options {
 }
 
 expr:
-      id=IDENTIFIER LPAREN expr (COMMA expr)* RPAREN # function
+      id=IDENTIFIER LPAREN (expr (COMMA expr)*)? RPAREN # function
     | QUESTION id=IDENTIFIER  # promptvariable
     | id=IDENTIFIER  # variable
     | number=NUMBER  # decimal

--- a/src/main/java/net/rptools/parser/DeterministicTreeParser.java
+++ b/src/main/java/net/rptools/parser/DeterministicTreeParser.java
@@ -85,7 +85,7 @@ public class DeterministicTreeParser {
 
   private AST createNode(Object value) {
     if (value instanceof BigDecimal bd) {
-      return new AST.NumberLiteral(bd.toPlainString(), bd);
+      return new AST.NumberLiteral(bd.toString(), bd);
     } else {
       var string = value.toString();
       return new AST.StringLiteral(string, string);

--- a/src/main/java/net/rptools/parser/InlineTreeFormatter.java
+++ b/src/main/java/net/rptools/parser/InlineTreeFormatter.java
@@ -64,7 +64,7 @@ public class InlineTreeFormatter {
     switch (node) {
       case AST.Variable variable -> sb.append(variable.variable());
       case AST.PromptVariable promptVariable -> sb.append("?").append(promptVariable.variable());
-      case AST.NumberLiteral numberLiteral -> sb.append(numberLiteral.value().toPlainString());
+      case AST.NumberLiteral numberLiteral -> sb.append(numberLiteral.text());
       case AST.StringLiteral stringLiteral -> sb.append(stringLiteral.text());
       case AST.Unary unary -> {
         if (unary.operator() != UnaryOperator.Plus) {

--- a/src/main/java/net/rptools/parser/Parser.java
+++ b/src/main/java/net/rptools/parser/Parser.java
@@ -57,6 +57,7 @@ import net.rptools.parser.function.impl.StrEquals;
 import net.rptools.parser.function.impl.StrNotEquals;
 import net.rptools.parser.function.impl.Subtraction;
 import net.rptools.parser.transform.Transformer;
+import org.antlr.v4.runtime.BailErrorStrategy;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 
@@ -201,7 +202,8 @@ public class Parser {
 
       ExpressionLexer lexer = new ExpressionLexer(CharStreams.fromString(s));
       ExpressionParser parser = new ExpressionParser(new CommonTokenStream(lexer));
-      AST t = new AstBuilderVisitor().visit(parser.expr());
+      parser.setErrorHandler(new BailErrorStrategy());
+      AST t = new AstBuilderVisitor().visit(parser.full().result);
 
       return new Expression(this, parser, t);
     } catch (Exception e) {

--- a/src/main/java/net/rptools/parser/ast/AST.java
+++ b/src/main/java/net/rptools/parser/ast/AST.java
@@ -17,6 +17,7 @@ package net.rptools.parser.ast;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * An immutable node in the AST.
@@ -53,14 +54,13 @@ public sealed interface AST {
 
   private static String toStringList(AST node) {
     var children = getChildren(node);
-    if (children.isEmpty()) {
+    if (!(node instanceof FunctionCall) && children.isEmpty()) {
       return node.text();
     }
 
     return "( "
-        + node.text()
-        + " "
-        + children.stream().map(AST::toStringList).collect(Collectors.joining(" "))
+        + Stream.concat(Stream.of(node.text()), children.stream().map(AST::toStringList))
+            .collect(Collectors.joining(" "))
         + " )";
   }
 

--- a/src/test/java/net/rptools/parser/ParserTest.java
+++ b/src/test/java/net/rptools/parser/ParserTest.java
@@ -54,4 +54,16 @@ public class ParserTest {
     var structure = xp.getTree().toStringTree();
     assertEquals(expectedStructure, structure, "The parsed AST must match the expected structure");
   }
+
+  @ParameterizedTest(name = "{0}; {1}")
+  @CsvFileSource(
+          resources = "ParserTest.testFailedParses.csv",
+          numLinesToSkip = 1,
+          delimiter = ';',
+          quoteCharacter = '`',
+          ignoreLeadingAndTrailingWhitespace = false)
+  public void testFailedParses(String label, String input) {
+    Parser p = new Parser();
+    assertThrows(ParserException.class, () -> p.parseExpression(input));
+  }
 }

--- a/src/test/resources/net/rptools/parser/ParserTest.testFailedParses.csv
+++ b/src/test/resources/net/rptools/parser/ParserTest.testFailedParses.csv
@@ -1,0 +1,2 @@
+Name;Input
+Assignment to string;"a" = 5

--- a/src/test/resources/net/rptools/parser/ParserTest.testSuccessfulParses.csv
+++ b/src/test/resources/net/rptools/parser/ParserTest.testSuccessfulParses.csv
@@ -53,6 +53,7 @@ Hex integer;0xFF; 0xFF
 Standard function: hex() single byte;hex(0xFF); ( hex 0xFF )
 Standard function: hex() single byte as two;hex(0x00FF); ( hex 0x00FF )
 Standard function: hex() two byte;hex(0xfac1); ( hex 0xfac1 )
+No parameters function;test(); ( test )
 Boolean: true;true; true
 Boolean: false;false; false
 Not: non-zero;!10; ( ! 10 )

--- a/src/test/resources/net/rptools/parser/ParserTest.testSuccessfulParses.csv
+++ b/src/test/resources/net/rptools/parser/ParserTest.testSuccessfulParses.csv
@@ -87,6 +87,9 @@ String equals mixed case: no;'Foo ' == ' fOo '; ( == 'Foo ' ' fOo ' )
 Standard function: eqs() mixed case strings;eqs('Foo ', ' fOo '); ( eqs 'Foo ' ' fOo ' )
 Standard function: eqs() same string;eqs('foo', 'foo'); ( eqs 'foo' 'foo' )
 Adjacent strings;"foo" "bar"; "foo"
+Adjacent strings (no whitespace);"foo""bar"; "foo"
+Adjacent strings (no whitespace, first is empty);"""bar"; ""
+Adjacent strings (no whitespace, second is empty);"foo"""; "foo"
 Multiline;`10 +
 17 +
 3`; ( + ( + 10 17 ) 3 )


### PR DESCRIPTION
Fixes various issues with #82 

Empty function calls were being rejected since the parser grammar was requiring at least one expression between the parenthesis. This has been fixed to make the arguments optional, thus allowing zero arguments to be passed.

Another issue was that we were calling `BigDecimal#toPlainString()` instead of `BigDecimal#toString()` as the antrl2 implementation did. A related "problem" is that we cann `BigDecimal#toString()` where it isn't needed - when formatting `NumberLiteral` nodes, we use the node text rather than formatting the `BigDecimal` value.

The final issue is that antlr is pretty lenient in its parsing by default. Since MapTool depends on parse errors to decide whether to try treating certain values as JSON, it is important that we are more particular about parsing only what the grammars define. To this end, the lexer now consumes all tokens, even unrecognized ones, and the parser explicitly matches to the end of the input. We also installed a `BailErrorStrategy` that throws on parse failures and does not perform error recovery. As a result, invalid inputs such as `"a" = 5` are rejected now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RPTools/parser/90)
<!-- Reviewable:end -->
